### PR TITLE
core: rewrite and simplify return type inference

### DIFF
--- a/src/cachew/tests/test_cachew.py
+++ b/src/cachew/tests/test_cachew.py
@@ -275,16 +275,13 @@ def test_unsupported_class(tmp_path: Path) -> None:
         def fun() -> List[UBad]:
             return [UBad()]
 
-    # now something a bit nastier
-    # TODO hmm, should really throw at the definition time... but can fix later I suppose
-    @cachew(cache_path=tmp_path)
-    def fun2() -> Iterable[Union[UGood, UBad]]:
-        yield UGood(x=1)
-        yield UBad()
-        yield UGood(x=2)
+    with pytest.raises(CachewException, match=".*can't infer type from.*"):
 
-    with pytest.raises(CachewException, match=".*doesn't look like a supported type.*"):
-        list(fun2())
+        @cachew(cache_path=tmp_path)
+        def fun2() -> Iterable[Union[UGood, UBad]]:
+            yield UGood(x=1)
+            yield UBad()
+            yield UGood(x=2)
 
 
 class TE2(NamedTuple):

--- a/src/cachew/utils.py
+++ b/src/cachew/utils.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import date, datetime
 from typing import (
     NamedTuple,
@@ -24,6 +25,14 @@ def is_union(cls) -> bool:
 
 class CachewException(RuntimeError):
     pass
+
+
+@dataclass
+class TypeNotSupported(CachewException):
+    type_: Type
+
+    def __str__(self) -> str:
+        return f"{self.type_} isn't supported by cachew. See https://github.com/karlicoss/cachew#features for the list of supported types."
 
 
 Types = Union[
@@ -78,3 +87,17 @@ def is_primitive(cls: Type) -> bool:
     True
     """
     return cls in PRIMITIVE_TYPES
+
+
+# https://stackoverflow.com/a/2166841/706389
+def is_namedtuple(t) -> bool:
+    b = getattr(t, '__bases__', None)
+    if b is None:
+        return False
+    if len(b) != 1 or b[0] != tuple:
+        return False
+    f = getattr(t, '_fields', None)
+    if not isinstance(f, tuple):
+        return False
+    # pylint: disable=unidiomatic-typecheck
+    return all(type(n) == str for n in f)  # noqa: E721


### PR DESCRIPTION
simplifies code by reusing existing marshalling routings

in addition enables support for https://github.com/karlicoss/cachew/issues/29 (needs a bit more work though)