### PR TITLE
general: 3.8 reached EOL, remove legacy code and make pytz optional dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest]  # todo windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         # vvv just an example of excluding stuff from matrix
         # exclude: [{platform: macos-latest, python-version: '3.6'}]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,8 @@ dependencies = [
     "appdirs"        ,  # default cache dir
     "sqlalchemy>=1.0",  # cache DB interaction
     "orjson",           # fast json serialization
-    "pytz",             # used to properly marshall pytz datatimes
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 ## these need to be set if you're planning to upload to pypi
 # description = "TODO"
@@ -32,6 +31,8 @@ Homepage = "https://github.com/karlicoss/cachew"
 
 [project.optional-dependencies]
 testing = [
+    "pytz", "types-pytz",  # optional runtime only dependency
+
     "pytest",
     "more-itertools",
     "patchy",  # for injecting sleeps and testing concurrent behaviour

--- a/src/cachew/legacy.py
+++ b/src/cachew/legacy.py
@@ -3,6 +3,7 @@ import warnings
 from dataclasses import dataclass
 from datetime import date, datetime
 from itertools import chain, islice
+from pathlib import Path
 from typing import (
     Any,
     Generic,
@@ -487,3 +488,20 @@ def test_ntbinder_primitive(tp, val) -> None:
     row = b.to_row(val)
     vv = b.from_row(list(row))
     assert vv == val
+
+
+def test_unique_columns(tmp_path: Path) -> None:
+    class Job(NamedTuple):
+        company: str
+        title: Optional[str]
+
+    class Breaky(NamedTuple):
+        job_title: int
+        job: Optional[Job]
+
+    assert [c.name for c in NTBinder.make(Breaky).columns] == [
+        'job_title',
+        '_job_is_null',
+        'job_company',
+        '_job_title',
+    ]

--- a/src/cachew/tests/marshall.py
+++ b/src/cachew/tests/marshall.py
@@ -13,7 +13,6 @@ from typing import (
 
 import orjson
 import pytest
-import pytz
 
 from ..marshall.cachew import CachewMarshall
 from ..marshall.common import Json
@@ -214,6 +213,8 @@ def test_union_str_dataclass(impl: Impl, count: int, gc_control, request) -> Non
 def test_datetimes(impl: Impl, count: int, gc_control, request) -> None:
     if impl == 'cattrs':
         pytest.skip('TODO support datetime with pytz for cattrs')
+
+    import pytz
 
     def factory(*, count: int):
         tzs = [

--- a/src/cachew/tests/test_future_annotations.py
+++ b/src/cachew/tests/test_future_annotations.py
@@ -25,9 +25,6 @@ class NewStyleTypes1:
 
 
 def test_types1(tmp_path: Path) -> None:
-    if sys.version_info[:2] <= (3, 8):
-        pytest.skip("too annoying to adjust for 3.8 and it's EOL soon anyway")
-
     # fmt: off
     obj = NewStyleTypes1(
         a_str   = 'abac',
@@ -85,9 +82,6 @@ def test_future_annotations(
     """
     Checks handling of postponed evaluation of annotations (from __future__ import annotations)
     """
-
-    if sys.version_info[:2] <= (3, 8):
-        pytest.skip("too annoying to adjust for 3.8 and it's EOL soon anyway")
 
     # NOTE: to avoid weird interactions with existing interpreter in which pytest is running
     #  , we compose a program and running in python directly instead

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ commands =
 deps =
     -e .[testing,optional]
 commands =
-    {envpython} -m mypy --install-types --non-interactive \
+    {envpython} -m mypy \
         -p {[testenv]package_name}       \
         # txt report is a bit more convenient to view on CI
         --txt-report  .coverage.mypy     \


### PR DESCRIPTION
also enable 3.13 on CI