### PR TITLE
backend.file: fix race condition during concurrent writes

### DIFF
--- a/src/cachew/backend/common.py
+++ b/src/cachew/backend/common.py
@@ -1,43 +1,47 @@
 import logging
 from abc import abstractmethod
 from collections.abc import Iterator, Sequence
+from contextlib import AbstractContextManager
 from pathlib import Path
 
 from ..common import SourceHash
 
 
-class AbstractBackend:
+class AbstractBackend(AbstractContextManager):
     @abstractmethod
     def __init__(self, cache_path: Path, *, logger: logging.Logger) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def __enter__(self):
-        raise NotImplementedError
-
-    def __exit__(self, *args) -> None:
-        raise NotImplementedError
-
     def get_old_hash(self) -> SourceHash | None:
         raise NotImplementedError
 
+    @abstractmethod
     def cached_blobs_total(self) -> int | None:
         raise NotImplementedError
 
+    @abstractmethod
     def cached_blobs(self) -> Iterator[bytes]:
         raise NotImplementedError
 
+    @abstractmethod
     def get_exclusive_write(self) -> bool:
-        '''
-        Returns whether it actually managed to get it
-        '''
+        """
+        Returns whether it actually managed to get it.
+        """
         raise NotImplementedError
 
+    @abstractmethod
     def write_new_hash(self, new_hash: SourceHash) -> None:
         raise NotImplementedError
 
+    @abstractmethod
     def flush_blobs(self, chunk: Sequence[bytes]) -> None:
         raise NotImplementedError
 
+    @abstractmethod
     def finalize(self, new_hash: SourceHash) -> None:
+        """
+        Atomically commit changes and make them visible to readers.
+        """
         raise NotImplementedError

--- a/src/cachew/backend/file.py
+++ b/src/cachew/backend/file.py
@@ -43,12 +43,12 @@ class FileBackend(AbstractBackend):
     @override
     def __exit__(self, *args) -> None:
         if self.jsonl_tmp_fw is not None:
-            # might still exist in case of early exit
-            self.jsonl_tmp.unlink(missing_ok=True)
-
-            # NOTE: need to unlink first
-            # otherwise possible that someone else might open the file before we unlink it
             self.jsonl_tmp_fw.close()
+            self.jsonl_tmp_fw = None
+
+            # Normally it wouldn't exist at this point
+            # But it might if some error happened and .finalize never kicked in
+            self.jsonl_tmp.unlink(missing_ok=True)
 
         if self.jsonl_fr is not None:
             self.jsonl_fr.close()
@@ -97,5 +97,8 @@ class FileBackend(AbstractBackend):
 
     @override
     def finalize(self, new_hash: SourceHash) -> None:
-        # TODO defensive??
+        assert self.jsonl_tmp_fw is not None  # should be only called after we get_exclusive_write
+        self.jsonl_tmp_fw.close()
+        self.jsonl_tmp_fw = None  # no need to do further cleanup in __exit__
+
         self.jsonl_tmp.rename(self.jsonl)

--- a/src/cachew/backend/file.py
+++ b/src/cachew/backend/file.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import (
     BinaryIO,
     Self,
+    override,
 )
 
 from ..common import SourceHash
@@ -14,16 +15,24 @@ class FileBackend(AbstractBackend):
     jsonl: Path
     jsonl_tmp: Path
     jsonl_fr: BinaryIO | None
+    """
+    read-only IO into self.jsonl
+    """
+
     jsonl_tmp_fw: BinaryIO | None
+    """
+    writable IO into self.jsonl
+    """
 
     def __init__(self, cache_path: Path, *, logger: logging.Logger) -> None:
         self.logger = logger
         self.jsonl = cache_path
-        self.jsonl_tmp = Path(str(self.jsonl) + '.tmp')
+        self.jsonl_tmp = self.jsonl.with_suffix(self.jsonl.suffix + '.tmp')
 
         self.jsonl_fr = None
         self.jsonl_tmp_fw = None
 
+    @override
     def __enter__(self) -> Self:
         try:
             self.jsonl_fr = self.jsonl.open('rb')
@@ -31,6 +40,7 @@ class FileBackend(AbstractBackend):
             self.jsonl_fr = None
         return self
 
+    @override
     def __exit__(self, *args) -> None:
         if self.jsonl_tmp_fw is not None:
             # might still exist in case of early exit
@@ -43,21 +53,25 @@ class FileBackend(AbstractBackend):
         if self.jsonl_fr is not None:
             self.jsonl_fr.close()
 
+    @override
     def get_old_hash(self) -> SourceHash | None:
         if self.jsonl_fr is None:
             return None
         hash_line = self.jsonl_fr.readline().rstrip(b'\n')
         return hash_line.decode('utf8')
 
+    @override
     def cached_blobs_total(self) -> int | None:
         # not really sure how to support that for a plaintext file?
         # could wc -l but it might be costly..
         return None
 
+    @override
     def cached_blobs(self) -> Iterator[bytes]:
         assert self.jsonl_fr is not None  # should be guaranteed by get_old_hash
         yield from self.jsonl_fr  # yields line by line
 
+    @override
     def get_exclusive_write(self) -> bool:
         # NOTE: opening in x (exclusive write) mode just in case, so it throws if file exists
         try:
@@ -68,10 +82,12 @@ class FileBackend(AbstractBackend):
         else:
             return True
 
+    @override
     def write_new_hash(self, new_hash: SourceHash) -> None:
         assert self.jsonl_tmp_fw is not None
         self.jsonl_tmp_fw.write(new_hash.encode('utf8') + b'\n')
 
+    @override
     def flush_blobs(self, chunk: Sequence[bytes]) -> None:
         fw = self.jsonl_tmp_fw
         assert fw is not None
@@ -79,6 +95,7 @@ class FileBackend(AbstractBackend):
             fw.write(blob)
             fw.write(b'\n')
 
-    def finalize(self, new_hash: SourceHash) -> None:  # noqa: ARG002
+    @override
+    def finalize(self, new_hash: SourceHash) -> None:
         # TODO defensive??
         self.jsonl_tmp.rename(self.jsonl)

--- a/src/cachew/backend/sqlite.py
+++ b/src/cachew/backend/sqlite.py
@@ -4,7 +4,7 @@ import time
 import warnings
 from collections.abc import Iterator, Sequence
 from pathlib import Path
-from typing import Self
+from typing import Self, override
 
 import sqlalchemy
 import sqlalchemy.exc
@@ -65,6 +65,7 @@ class SqliteBackend(AbstractBackend):
         self.table_cache_tmp = Table('cache_tmp', self.meta, Column('data', sqlalchemy.BLOB))
         # fmt: on
 
+    @override
     def __enter__(self) -> Self:
         # NOTE: deferred transaction
         self.transaction = self.connection.begin()
@@ -72,11 +73,13 @@ class SqliteBackend(AbstractBackend):
         self.transaction.__enter__()
         return self
 
+    @override
     def __exit__(self, *args) -> None:
         self.transaction.__exit__(*args)
         self.connection.close()
         self.engine.dispose()
 
+    @override
     def get_old_hash(self) -> SourceHash | None:
         # first, try to do as much as possible read-only, benefiting from deferred transaction
         old_hashes: Sequence
@@ -101,10 +104,12 @@ class SqliteBackend(AbstractBackend):
             old_hash = old_hashes[0][0]  # returns a tuple...
         return old_hash
 
+    @override
     def cached_blobs_total(self) -> int | None:
         [(total,)] = self.connection.execute(sqlalchemy.select(sqlalchemy.func.count()).select_from(self.table_cache))
         return total
 
+    @override
     def cached_blobs(self) -> Iterator[bytes]:
         rows = self.connection.execute(self.table_cache.select())
         # by default, sqlalchemy wraps all results into Row object
@@ -130,6 +135,7 @@ class SqliteBackend(AbstractBackend):
         for (blob,) in row_iterator:
             yield blob
 
+    @override
     def get_exclusive_write(self) -> bool:
         # NOTE on recursive calls
         # somewhat magically, they should work as expected with no extra database inserts?
@@ -165,6 +171,7 @@ class SqliteBackend(AbstractBackend):
                 raise e
         return True
 
+    @override
     def flush_blobs(self, chunk: Sequence[bytes]) -> None:
         # uhh. this gives a huge speedup for inserting
         # since we don't have to create intermediate dictionaries
@@ -176,6 +183,7 @@ class SqliteBackend(AbstractBackend):
         # idk what benefit sqlalchemy gives at this point, seems to just complicate things
         self.connection.exec_driver_sql(insert_into_table_cache_tmp_raw, [(c,) for c in chunk])
 
+    @override
     def finalize(self, new_hash: SourceHash) -> None:
         # delete hash first, so if we are interrupted somewhere, it mismatches next time and everything is recomputed
         self.connection.execute(self.table_hash.delete())
@@ -189,3 +197,8 @@ class SqliteBackend(AbstractBackend):
         self.connection.execute(text(f"ALTER TABLE `{self.table_cache_tmp.name}` RENAME TO `{self.table_cache.name}`"))
 
         self.connection.execute(self.table_hash.insert().values([{'value': new_hash}]))
+
+    @override
+    def write_new_hash(self, new_hash: SourceHash) -> None:
+        # TODO think later maybe fine to keep a no op implementation?
+        raise NotImplementedError("shouldn't be used for SqliteBackend")

--- a/src/cachew/tests/test_cachew.py
+++ b/src/cachew/tests/test_cachew.py
@@ -1,7 +1,6 @@
 # ruff: noqa: ARG001  # ruff thinks pytest fixtures are unused arguments
 import hashlib
 import inspect
-import platform
 import string
 import sys
 import time
@@ -892,7 +891,6 @@ def fuzz_cachew_impl():
 # TODO how to run it enough times on CI and increase likelihood of failing?
 # for now, stress testing manually:
 # while PYTHONPATH=src pytest -s cachew -k concurrent_writes ; do sleep 0.5; done
-@pytest.mark.xfail(condition=platform.system() == 'Darwin', reason='seems like file writes might not be atomic on osx?')
 def test_concurrent_writes(tmp_path: Path, fuzz_cachew_impl) -> None:
     cache_path = tmp_path / 'cache.sqlite'
 


### PR DESCRIPTION
This is roughly what was happening previously:
```
P_A: get_exclusive_write()   → creates jsonl.tmp (inode I1)
P_A: written_to_cache()      → writes I1, yields items
P_A: finalize()              → rename jsonl.tmp → jsonl (I1 now at "jsonl",
                                jsonl.tmp doesn't exist)

P_B: get_exclusive_write()   → jsonl.tmp doesn't exist → creates it (I2) ✓
P_B: written_to_cache()      → starts writing I2, yields some items to caller

P_A: __exit__()              → unlink(jsonl.tmp)   ← deletes I2's path!

P_B: finalize()              → rename(jsonl.tmp, jsonl) → FileNotFoundError
P_B: outer except            → cachew_error(e); yield from func(...)
                              → caller gets the items it already saw, again
```

for some reason it only reproduced on osx previously; to reproduce on linux had to inject some sleeps:

```
    @OverRide
    def __exit__(self, *args) -> None:
        if self.jsonl_tmp_fw is not None:
            # FUZZ: hold the bug window open
            import os, random, time

            if os.environ.get('CACHEW_FUZZ_FILE_BACKEND'):
                time.sleep(random.uniform(0.5, 1.5))

            self.jsonl_tmp_fw.close()
            self.jsonl_tmp_fw = None
```