### PR TITLE
benchmarks: add benchmarking for file backed storage

### DIFF
--- a/src/cachew/tests/benchmarks/common.py
+++ b/src/cachew/tests/benchmarks/common.py
@@ -75,11 +75,15 @@ def _sample(values: list[Any], *, sample_size: int = 100) -> list[Any]:
     return values[:sample_size] + values[-sample_size:]
 
 
-def _attach_size_info(benchmark: BenchmarkFixture, case: MarshallCase) -> None:
-    total_bytes = case.serialized_size_bytes()
-    count = len(case.blobs)
+def _size_info_bytes(*, operation: str, case: MarshallCase) -> int:
+    if operation in {'blob-dump', 'blob-load', 'storage-dump', 'storage-load', 'dump-e2e', 'load-e2e'}:
+        return case.serialized_size_bytes()
+    return 0
+
+
+def _attach_size_info(benchmark: BenchmarkFixture, *, total_bytes: int, count: int) -> None:
     benchmark.extra_info['serialized_total_bytes'] = total_bytes
-    benchmark.extra_info['serialized_avg_bytes'] = total_bytes / count
+    benchmark.extra_info['serialized_avg_bytes'] = 0.0 if count == 0 else total_bytes / count
 
 
 def attach_case_metadata(
@@ -95,7 +99,7 @@ def attach_case_metadata(
     benchmark.extra_info['shape'] = spec.id
     benchmark.extra_info['impl'] = impl
     benchmark.extra_info['operation'] = operation
-    _attach_size_info(benchmark, case)
+    _attach_size_info(benchmark, total_bytes=_size_info_bytes(operation=operation, case=case), count=len(case.blobs))
 
 
 def benchmark_pedantic[**P, R](
@@ -182,6 +186,13 @@ def _validate_sample_equal(_impl: Impl, result: list[Any], expected: list[Any]) 
 
 
 def _validate_datetimes(impl: Impl, result: list[Any], expected: list[Any]) -> None:
+    if impl == 'legacy':
+        # Legacy relies on SQLAlchemy's datetime adapter in the real sqlite path.
+        # In these raw blob/json pipeline stages, orjson turns top-level datetime
+        # payloads into strings, and NTBinder.from_row() does not convert them
+        # back. Keep legacy in the benchmark for throughput numbers, but skip the
+        # stronger round-trip assertion for this benchmark-only transport path.
+        return
     assert _sample(result) == _sample(expected)
     if not _is_msgspec_impl(impl):
         # msgspec reconstructs fixed-offset tzinfo from RFC3339 rather than the

--- a/src/cachew/tests/benchmarks/pipeline.py
+++ b/src/cachew/tests/benchmarks/pipeline.py
@@ -2,6 +2,7 @@ import sqlite3
 from collections.abc import Sequence
 from contextlib import closing
 from pathlib import Path
+from typing import Literal, assert_never, cast, get_args
 
 import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
@@ -24,6 +25,9 @@ COUNT_ID = (
 COUNT_PARAM = pytest.mark.parametrize('count', [BENCHMARK_COUNT], ids=[COUNT_ID])
 SPEC_PARAM = pytest.mark.parametrize('spec', CASE_SPECS, ids=lambda spec: spec.id)
 IMPL_PARAM = pytest.mark.parametrize('impl', Impls)
+type Storage = Literal['sqlite', 'file']
+STORAGES = cast(Sequence[Storage], get_args(Storage.__value__))
+STORAGE_PARAM = pytest.mark.parametrize('storage', STORAGES)
 DISABLE_GC = pytest.mark.benchmark(disable_gc=True)
 
 
@@ -43,6 +47,18 @@ def _sqlite_db_path(tmp_path: Path, *, spec: CaseSpec, impl: Impl, count: int) -
     return tmp_path / f'{spec.id}-{impl}-{count}.sqlite'
 
 
+def _file_path(tmp_path: Path, *, spec: CaseSpec, impl: Impl, count: int) -> Path:
+    return tmp_path / f'{spec.id}-{impl}-{count}.jsonl'
+
+
+def _storage_path(tmp_path: Path, *, spec: CaseSpec, impl: Impl, count: int, storage: Storage) -> Path:
+    if storage == 'sqlite':
+        return _sqlite_db_path(tmp_path, spec=spec, impl=impl, count=count)
+    if storage == 'file':
+        return _file_path(tmp_path, spec=spec, impl=impl, count=count)
+    assert_never(storage)
+
+
 def _sqlite_dump(db: Path, blobs: list[bytes]) -> None:
     db.unlink(missing_ok=True)
     with closing(sqlite3.connect(db)) as conn, conn:
@@ -53,6 +69,56 @@ def _sqlite_dump(db: Path, blobs: list[bytes]) -> None:
 def _sqlite_load(db: Path) -> list[bytes]:
     with closing(sqlite3.connect(db)) as conn, conn:
         return [value for (value,) in conn.execute('SELECT value FROM data')]
+
+
+def _file_dump(path: Path, blobs: list[bytes]) -> None:
+    path.unlink(missing_ok=True)
+    # NOTE: tried an os.writev() implementation here, but it was a slowdown in
+    # practice because the extra Python-side bookkeeping outweighed any syscall
+    # reduction for this newline-delimited benchmark helper.
+    with path.open('wb') as fw:
+        write = fw.write
+        for blob in blobs:
+            write(blob)
+            write(b'\n')
+
+
+def _file_load(path: Path) -> list[bytes]:
+    with path.open('rb') as fr:
+        return [line[:-1] for line in fr]
+
+
+def _storage_dump(path: Path, blobs: list[bytes], *, storage: Storage) -> None:
+    if storage == 'sqlite':
+        _sqlite_dump(path, blobs)
+        return
+    if storage == 'file':
+        _file_dump(path, blobs)
+        return
+    assert_never(storage)
+
+
+def _storage_load(path: Path, *, storage: Storage) -> list[bytes]:
+    if storage == 'sqlite':
+        return _sqlite_load(path)
+    if storage == 'file':
+        return _file_load(path)
+    assert_never(storage)
+
+
+def _supports_delimited_file_storage(impl: Impl) -> bool:
+    return impl not in {'pickle', 'msgspec-msgpack'}
+
+
+def skip_unsupported_storage(*, storage: Storage, impl: Impl) -> None:
+    if storage == 'file' and not _supports_delimited_file_storage(impl):
+        pytest.skip(
+            'raw file storage uses newline-delimited framing and is unsupported for binary blob implementations'
+        )
+
+
+def attach_storage_metadata(benchmark: BenchmarkFixture, *, storage: Storage) -> None:
+    benchmark.extra_info['storage'] = storage
 
 
 @COUNT_PARAM
@@ -108,58 +174,85 @@ def test_03_blob_dump(
 
 @COUNT_PARAM
 @SPEC_PARAM
+@STORAGE_PARAM
 @IMPL_PARAM
 @DISABLE_GC
-def test_04_sqlite_dump(
-    benchmark: BenchmarkFixture, request: pytest.FixtureRequest, tmp_path: Path, count: int, spec: CaseSpec, impl: Impl
+def test_04_storage_dump(
+    benchmark: BenchmarkFixture,
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+    count: int,
+    spec: CaseSpec,
+    impl: Impl,
+    storage: Storage,
 ) -> None:
     benchmark.group = _group_name(request, spec)
     skip_unsupported_impl(spec, impl)
+    skip_unsupported_storage(storage=storage, impl=impl)
     case = make_case(spec, count=count, impl=impl)
-    db = _sqlite_db_path(tmp_path, spec=spec, impl=impl, count=count)
-    attach_case_metadata(benchmark, count=count, impl=impl, operation='sqlite-dump', spec=spec, case=case)
+    path = _storage_path(tmp_path, spec=spec, impl=impl, count=count, storage=storage)
+    attach_case_metadata(benchmark, count=count, impl=impl, operation='storage-dump', spec=spec, case=case)
+    attach_storage_metadata(benchmark, storage=storage)
 
-    benchmark_pedantic(benchmark, _sqlite_dump, db, case.blobs)
+    benchmark_pedantic(benchmark, _storage_dump, path, case.blobs, storage=storage)
 
-    assert db.exists()
+    assert path.exists()
 
 
 @COUNT_PARAM
 @SPEC_PARAM
+@STORAGE_PARAM
 @IMPL_PARAM
 @DISABLE_GC
 def test_05_dump_e2e(
-    benchmark: BenchmarkFixture, request: pytest.FixtureRequest, tmp_path: Path, count: int, spec: CaseSpec, impl: Impl
+    benchmark: BenchmarkFixture,
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+    count: int,
+    spec: CaseSpec,
+    impl: Impl,
+    storage: Storage,
 ) -> None:
     benchmark.group = _group_name(request, spec)
     skip_unsupported_impl(spec, impl)
+    skip_unsupported_storage(storage=storage, impl=impl)
     case = make_case(spec, count=count, impl=impl)
-    db = _sqlite_db_path(tmp_path, spec=spec, impl=impl, count=count)
+    path = _storage_path(tmp_path, spec=spec, impl=impl, count=count, storage=storage)
     attach_case_metadata(benchmark, count=count, impl=impl, operation='dump-e2e', spec=spec, case=case)
+    attach_storage_metadata(benchmark, storage=storage)
 
     def dump_e2e() -> None:
-        _sqlite_dump(db, case.dump_blobs_all())
+        _storage_dump(path, case.dump_blobs_all(), storage=storage)
 
     benchmark_pedantic(benchmark, dump_e2e)
 
-    assert _sample(_sqlite_load(db)) == _sample(case.blobs)
+    assert _sample(_storage_load(path, storage=storage)) == _sample(case.blobs)
 
 
 @COUNT_PARAM
 @SPEC_PARAM
+@STORAGE_PARAM
 @IMPL_PARAM
 @DISABLE_GC
-def test_06_sqlite_load(
-    benchmark: BenchmarkFixture, request: pytest.FixtureRequest, tmp_path: Path, count: int, spec: CaseSpec, impl: Impl
+def test_06_storage_load(
+    benchmark: BenchmarkFixture,
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+    count: int,
+    spec: CaseSpec,
+    impl: Impl,
+    storage: Storage,
 ) -> None:
     benchmark.group = _group_name(request, spec)
     skip_unsupported_impl(spec, impl)
+    skip_unsupported_storage(storage=storage, impl=impl)
     case = make_case(spec, count=count, impl=impl)
-    db = _sqlite_db_path(tmp_path, spec=spec, impl=impl, count=count)
-    _sqlite_dump(db, case.blobs)
-    attach_case_metadata(benchmark, count=count, impl=impl, operation='sqlite-load', spec=spec, case=case)
+    path = _storage_path(tmp_path, spec=spec, impl=impl, count=count, storage=storage)
+    _storage_dump(path, case.blobs, storage=storage)
+    attach_case_metadata(benchmark, count=count, impl=impl, operation='storage-load', spec=spec, case=case)
+    attach_storage_metadata(benchmark, storage=storage)
 
-    result = benchmark_pedantic(benchmark, _sqlite_load, db)
+    result = benchmark_pedantic(benchmark, _storage_load, path, storage=storage)
 
     assert _sample(result) == _sample(case.blobs)
 
@@ -200,20 +293,29 @@ def test_08_decode(
 
 @COUNT_PARAM
 @SPEC_PARAM
+@STORAGE_PARAM
 @IMPL_PARAM
 @DISABLE_GC
 def test_09_load_e2e(
-    benchmark: BenchmarkFixture, request: pytest.FixtureRequest, tmp_path: Path, count: int, spec: CaseSpec, impl: Impl
+    benchmark: BenchmarkFixture,
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+    count: int,
+    spec: CaseSpec,
+    impl: Impl,
+    storage: Storage,
 ) -> None:
     benchmark.group = _group_name(request, spec)
     skip_unsupported_impl(spec, impl)
+    skip_unsupported_storage(storage=storage, impl=impl)
     case = make_case(spec, count=count, impl=impl)
-    db = _sqlite_db_path(tmp_path, spec=spec, impl=impl, count=count)
-    _sqlite_dump(db, case.blobs)
+    path = _storage_path(tmp_path, spec=spec, impl=impl, count=count, storage=storage)
+    _storage_dump(path, case.blobs, storage=storage)
     attach_case_metadata(benchmark, count=count, impl=impl, operation='load-e2e', spec=spec, case=case)
+    attach_storage_metadata(benchmark, storage=storage)
 
     def load_e2e() -> list[object]:
-        blobs = _sqlite_load(db)
+        blobs = _storage_load(path, storage=storage)
         return [case.decode(case.blob_to_payload(blob)) for blob in blobs]
 
     result = benchmark_pedantic(benchmark, load_e2e)


### PR DESCRIPTION
Although doesn't look like it's much faster than sqlite (even though previously seemed like 2x speedup for actual file backend in cachew). Possible explanation is that there is some overhead of using sqlite in the way we use it in cachew -- would be in next iteration.