### PR TITLE
benchmarks: use streaming/chunking in the same way and account for object creation

### DIFF
--- a/src/cachew/__init__.py
+++ b/src/cachew/__init__.py
@@ -81,6 +81,8 @@ BACKENDS: dict[Backend, type[AbstractBackend]] = {
     'sqlite': SqliteBackend,
 }
 
+_DEFAULT_CHUNK_BY = 100
+
 
 type PathProvider[**P] = PathIsh | Callable[P, PathIsh]
 type HashFunction[**P] = Callable[P, SourceHash]
@@ -284,7 +286,7 @@ def cachew_impl[**P](
     cls: type | tuple[Kind, type] | None = None,
     depends_on: HashFunction[P] = default_hash,
     logger: logging.Logger | None = None,
-    chunk_by: int = 100,
+    chunk_by: int = _DEFAULT_CHUNK_BY,
     # NOTE: allowed values for chunk_by depend on the system.
     # some systems (to be more specific, sqlite builds), it might be too large and cause issues
     # ideally this would be more defensive/autodetected, maybe with a warning?

--- a/src/cachew/tests/benchmarks/pipeline.py
+++ b/src/cachew/tests/benchmarks/pipeline.py
@@ -1,5 +1,5 @@
 import sqlite3
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from contextlib import closing
 from pathlib import Path
 from typing import Any, Literal, assert_never, cast, get_args
@@ -7,7 +7,7 @@ from typing import Any, Literal, assert_never, cast, get_args
 import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
 
-from ... import cachew
+from ... import _DEFAULT_CHUNK_BY, cachew
 from .common import (
     BENCHMARK_COUNT,
     CASE_SPECS,
@@ -32,6 +32,9 @@ STORAGE_PARAM = pytest.mark.parametrize('storage', STORAGES)
 REAL_IMPL = 'cachew-real'
 REAL_IMPL_PARAM = pytest.mark.parametrize('real_impl', [REAL_IMPL])
 DISABLE_GC = pytest.mark.benchmark(disable_gc=True)
+# Match cachew's default chunking so synthetic storage/e2e benchmarks follow
+# the same batching shape as the real cachew backend path.
+_DUMP_CHUNK_BY = _DEFAULT_CHUNK_BY
 
 
 def _sample(values: Sequence[object], *, sample_size: int = 100) -> list[object]:
@@ -71,50 +74,29 @@ def _storage_path(tmp_path: Path, *, spec: CaseSpec, impl: Impl, count: int, sto
     assert_never(storage)
 
 
-def _sqlite_dump(db: Path, blobs: list[bytes]) -> None:
-    db.unlink(missing_ok=True)
+def _sqlite_iter(db: Path) -> Iterator[bytes]:
     with closing(sqlite3.connect(db)) as conn, conn:
-        conn.execute('CREATE TABLE data (value BLOB)')
-        conn.executemany('INSERT INTO data (value) VALUES (?)', [(blob,) for blob in blobs])
+        for (value,) in conn.execute('SELECT value FROM data'):
+            yield value
 
 
-def _sqlite_load(db: Path) -> list[bytes]:
-    with closing(sqlite3.connect(db)) as conn, conn:
-        return [value for (value,) in conn.execute('SELECT value FROM data')]
-
-
-def _file_dump(path: Path, blobs: list[bytes]) -> None:
-    path.unlink(missing_ok=True)
-    # NOTE: tried an os.writev() implementation here, but it was a slowdown in
-    # practice because the extra Python-side bookkeeping outweighed any syscall
-    # reduction for this newline-delimited benchmark helper.
-    with path.open('wb') as fw:
-        write = fw.write
-        for blob in blobs:
-            write(blob)
-            write(b'\n')
-
-
-def _file_load(path: Path) -> list[bytes]:
+def _file_iter(path: Path) -> Iterator[bytes]:
     with path.open('rb') as fr:
-        return [line[:-1] for line in fr]
-
-
-def _storage_dump(path: Path, blobs: list[bytes], *, storage: Storage) -> None:
-    if storage == 'sqlite':
-        _sqlite_dump(path, blobs)
-        return
-    if storage == 'file':
-        _file_dump(path, blobs)
-        return
-    assert_never(storage)
+        for line in fr:
+            yield line[:-1]
 
 
 def _storage_load(path: Path, *, storage: Storage) -> list[bytes]:
+    return list(_storage_iter(path, storage=storage))
+
+
+def _storage_iter(path: Path, *, storage: Storage) -> Iterator[bytes]:
     if storage == 'sqlite':
-        return _sqlite_load(path)
+        yield from _sqlite_iter(path)
+        return
     if storage == 'file':
-        return _file_load(path)
+        yield from _file_iter(path)
+        return
     assert_never(storage)
 
 
@@ -131,6 +113,50 @@ def skip_unsupported_storage(*, storage: Storage, impl: Impl) -> None:
 
 def attach_storage_metadata(benchmark: BenchmarkFixture, *, storage: Storage) -> None:
     benchmark.extra_info['storage'] = storage
+
+
+def _iter_blobs_from_objects(
+    *,
+    objects: Iterable[object],
+    encode,
+    payload_to_blob,
+) -> Iterator[bytes]:
+    for obj in objects:
+        yield payload_to_blob(encode(obj))
+
+
+def _storage_dump_streaming(
+    path: Path,
+    *,
+    blobs: Iterable[bytes],
+    storage: Storage,
+    chunk_by: int = _DUMP_CHUNK_BY,
+) -> None:
+    if storage == 'sqlite':
+        path.unlink(missing_ok=True)
+        with closing(sqlite3.connect(path)) as conn, conn:
+            conn.execute('CREATE TABLE data (value BLOB)')
+            chunk: list[bytes] = []
+            for blob in blobs:
+                chunk.append(blob)
+                if len(chunk) >= chunk_by:
+                    conn.executemany('INSERT INTO data (value) VALUES (?)', [(blob,) for blob in chunk])
+                    chunk = []
+            if len(chunk) > 0:
+                conn.executemany('INSERT INTO data (value) VALUES (?)', [(blob,) for blob in chunk])
+        return
+    if storage == 'file':
+        path.unlink(missing_ok=True)
+        # NOTE: tried an os.writev() implementation here, but it was a slowdown
+        # in practice because the extra Python-side bookkeeping outweighed any
+        # syscall reduction for this newline-delimited benchmark helper.
+        with path.open('wb') as fw:
+            write = fw.write
+            for blob in blobs:
+                write(blob)
+                write(b'\n')
+        return
+    assert_never(storage)
 
 
 def _make_real_cachew_fun(*, path: Path, spec: CaseSpec, count: int, storage: Storage) -> Any:
@@ -220,7 +246,7 @@ def test_04_storage_dump(
     attach_case_metadata(benchmark, count=count, impl=impl, operation='storage-dump', spec=spec, case=case)
     attach_storage_metadata(benchmark, storage=storage)
 
-    benchmark_pedantic(benchmark, _storage_dump, path, case.blobs, storage=storage)
+    benchmark_pedantic(benchmark, _storage_dump_streaming, path, blobs=case.blobs, storage=storage)
 
     assert path.exists()
 
@@ -248,7 +274,17 @@ def test_05_dump_e2e(
     attach_storage_metadata(benchmark, storage=storage)
 
     def dump_e2e() -> None:
-        _storage_dump(path, case.dump_blobs_all(), storage=storage)
+        # Include object construction here so this synthetic miss-path benchmark
+        # stays comparable to the real cachew e2e write benchmark below.
+        _storage_dump_streaming(
+            path,
+            blobs=_iter_blobs_from_objects(
+                objects=spec.build_objects(count),
+                encode=case.encode,
+                payload_to_blob=case.payload_to_blob,
+            ),
+            storage=storage,
+        )
 
     benchmark_pedantic(benchmark, dump_e2e)
 
@@ -305,7 +341,7 @@ def test_06_storage_load(
     skip_unsupported_storage(storage=storage, impl=impl)
     case = make_case(spec, count=count, impl=impl)
     path = _storage_path(tmp_path, spec=spec, impl=impl, count=count, storage=storage)
-    _storage_dump(path, case.blobs, storage=storage)
+    _storage_dump_streaming(path, blobs=case.blobs, storage=storage)
     attach_case_metadata(benchmark, count=count, impl=impl, operation='storage-load', spec=spec, case=case)
     attach_storage_metadata(benchmark, storage=storage)
 
@@ -367,13 +403,12 @@ def test_09_load_e2e(
     skip_unsupported_storage(storage=storage, impl=impl)
     case = make_case(spec, count=count, impl=impl)
     path = _storage_path(tmp_path, spec=spec, impl=impl, count=count, storage=storage)
-    _storage_dump(path, case.blobs, storage=storage)
+    _storage_dump_streaming(path, blobs=case.blobs, storage=storage)
     attach_case_metadata(benchmark, count=count, impl=impl, operation='load-e2e', spec=spec, case=case)
     attach_storage_metadata(benchmark, storage=storage)
 
     def load_e2e() -> list[object]:
-        blobs = _storage_load(path, storage=storage)
-        return [case.decode(case.blob_to_payload(blob)) for blob in blobs]
+        return [case.decode(case.blob_to_payload(blob)) for blob in _storage_iter(path, storage=storage)]
 
     result = benchmark_pedantic(benchmark, load_e2e)
 


### PR DESCRIPTION
This makes the 'synthetic' benchmarks match 'real' benchmarks much closer, previously (baseline) they were undercounting.

Whereas now, cachew-file and cachew-real-file are very close, which is more what's expected.

```
--------------------------------------------------------------------------------- benchmark 'nested-dataclass-05_dump_e2e | Rounds: 50 | Iterations: 1': 8 tests --------------------------------------------------------------------------------
Name (time in ms)                                                                    Min              Max             Mean            StdDev            Median            IQR            Outliers  Avg Bytes                Total Bytes
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_05_dump_e2e[cachew-file-nested-dataclass-100k] (0005_baselin)                  44.3 (1.0)       48.6 (1.0)       46.0 (1.0)         0.9 (1.0)        45.9 (1.0)      0.9 (1.0)          14;4    59.5556          5955560
test_05_dump_e2e[cachew-sqlite-nested-dataclass-100k] (0005_baselin)                92.5 (2.09)      99.2 (2.04)      96.1 (2.09)        1.5 (1.64)       96.0 (2.09)     1.7 (2.00)         15;1    59.5556          5955560
test_05_real_dump_e2e[cachew-real-file-nested-dataclass-100k] (NOW)                124.3 (2.80)     135.5 (2.79)     128.8 (2.80)        2.8 (3.05)      129.1 (2.81)     3.9 (4.56)         21;0    59.5556          5955560
test_05_real_dump_e2e[cachew-real-file-nested-dataclass-100k] (0005_baselin)       125.5 (2.83)     136.8 (2.81)     129.8 (2.82)        2.2 (2.38)      129.8 (2.83)     2.5 (2.86)         17;1    59.5556          5955560
test_05_dump_e2e[cachew-file-nested-dataclass-100k] (NOW)                          127.1 (2.87)     135.3 (2.78)     131.7 (2.87)        2.2 (2.38)      132.0 (2.88)     2.5 (2.92)         20;0    59.5556          5955560
test_05_dump_e2e[cachew-sqlite-nested-dataclass-100k] (NOW)                        166.4 (3.76)     180.6 (3.71)     173.7 (3.78)        3.0 (3.31)      174.0 (3.79)     3.5 (4.07)         13;1    59.5556          5955560
test_05_real_dump_e2e[cachew-real-sqlite-nested-dataclass-100k] (NOW)              263.4 (5.94)     286.9 (5.90)     275.2 (5.99)        5.2 (5.68)      275.4 (6.00)     6.9 (7.95)         18;0    59.5556          5955560
test_05_real_dump_e2e[cachew-real-sqlite-nested-dataclass-100k] (0005_baselin)     265.1 (5.98)     283.9 (5.84)     275.2 (5.99)        4.3 (4.73)      276.0 (6.01)     6.5 (7.57)         18;0    59.5556          5955560
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```