### PR TITLE
backend.sqlite: speedup dumping (cache writes) by compiling the insert statement early

### DIFF
--- a/src/cachew/backend/sqlite.py
+++ b/src/cachew/backend/sqlite.py
@@ -58,12 +58,16 @@ class SqliteBackend(AbstractBackend):
         self.meta = sqlalchemy.MetaData()
         self.table_hash = Table('hash', self.meta, Column('value', sqlalchemy.String))
 
-        # fmt: off
         # actual cache
-        self.table_cache     = Table('cache'    , self.meta, Column('data', sqlalchemy.BLOB))
+        self.table_cache     = Table('cache'    , self.meta, Column('data', sqlalchemy.BLOB))  # fmt: skip
         # temporary table, we use it to insert and then (atomically?) rename to the above table at the very end
-        self.table_cache_tmp = Table('cache_tmp', self.meta, Column('data', sqlalchemy.BLOB))
-        # fmt: on
+        self.table_cache_tmp = Table('cache_tmp', self.meta, Column('data', sqlalchemy.BLOB))  # fmt: skip
+
+        # Cachew writes flush many small chunks, so avoid recompiling the same INSERT statement on every flush.
+        # This raw qmark INSERT avoids SQLAlchemy's per-row dictionary overhead.
+        self._insert_into_table_cache_tmp_raw = str(
+            self.table_cache_tmp.insert().compile(dialect=sqlite.dialect(paramstyle='qmark'))
+        )
 
     @override
     def __enter__(self) -> Self:
@@ -173,15 +177,9 @@ class SqliteBackend(AbstractBackend):
 
     @override
     def flush_blobs(self, chunk: Sequence[bytes]) -> None:
-        # uhh. this gives a huge speedup for inserting
-        # since we don't have to create intermediate dictionaries
-        # TODO move this to __init__?
-        insert_into_table_cache_tmp_raw = str(
-            self.table_cache_tmp.insert().compile(dialect=sqlite.dialect(paramstyle='qmark'))
-        )
         # I also tried setting paramstyle='qmark' in create_engine, but it seems to be ignored :(
         # idk what benefit sqlalchemy gives at this point, seems to just complicate things
-        self.connection.exec_driver_sql(insert_into_table_cache_tmp_raw, [(c,) for c in chunk])
+        self.connection.exec_driver_sql(self._insert_into_table_cache_tmp_raw, [(c,) for c in chunk])
 
     @override
     def finalize(self, new_hash: SourceHash) -> None:


### PR DESCRIPTION
2x-3x speedup for dumping into database (NOW vs baseline), basically matching synthetic sqlite benchmark now!

```
-------------------------------------------------------------------------------- benchmark 'datetimes-05_dump_e2e | Rounds: 50 | Iterations: 1': 4 tests ---------------------------------------------------------------------------------
Name (time in ms)                                                             Min              Max             Mean            StdDev            Median            IQR            Outliers  Avg Bytes                Total Bytes
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_05_dump_e2e[cachew-sqlite-datetimes-100k] (NOW)                        239.9 (1.0)      259.8 (1.0)      247.0 (1.0)         3.7 (1.0)       246.6 (1.0)      4.5 (1.0)          14;1      53.92          5392000
test_05_dump_e2e[cachew-sqlite-datetimes-100k] (0006_baselin)               241.6 (1.01)     266.2 (1.02)     250.5 (1.01)        5.3 (1.42)      250.2 (1.01)     7.4 (1.64)         12;1      53.92          5392000
test_05_real_dump_e2e[cachew-real-sqlite-datetimes-100k] (NOW)              277.9 (1.16)     297.1 (1.14)     282.5 (1.14)        3.9 (1.05)      281.8 (1.14)     5.5 (1.22)         13;1      53.92          5392000
test_05_real_dump_e2e[cachew-real-sqlite-datetimes-100k] (0006_baselin)     361.2 (1.51)     377.9 (1.45)     370.6 (1.50)        3.9 (1.06)      370.6 (1.50)     6.1 (1.34)         17;0      53.92          5392000
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--------------------------------------------------------------------------------- benchmark 'nested-dataclass-05_dump_e2e | Rounds: 50 | Iterations: 1': 4 tests --------------------------------------------------------------------------------
Name (time in ms)                                                                    Min              Max             Mean            StdDev            Median            IQR            Outliers  Avg Bytes                Total Bytes
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_05_dump_e2e[cachew-sqlite-nested-dataclass-100k] (0006_baselin)               166.1 (1.0)      369.5 (2.06)     182.2 (1.05)       34.8 (12.03)     174.0 (1.00)     6.5 (1.50)          3;5    59.5556          5955560
test_05_dump_e2e[cachew-sqlite-nested-dataclass-100k] (NOW)                        168.0 (1.01)     179.4 (1.0)      173.6 (1.0)         2.9 (1.0)       173.8 (1.0)      4.5 (1.05)         21;0    59.5556          5955560
test_05_real_dump_e2e[cachew-real-sqlite-nested-dataclass-100k] (NOW)              183.2 (1.10)     197.7 (1.10)     189.6 (1.09)        3.0 (1.05)      189.9 (1.09)     4.3 (1.0)          16;0    59.5556          5955560
test_05_real_dump_e2e[cachew-real-sqlite-nested-dataclass-100k] (0006_baselin)     265.6 (1.60)     280.9 (1.57)     273.5 (1.58)        3.4 (1.17)      273.7 (1.57)     4.9 (1.14)         19;0    59.5556          5955560
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------- benchmark 'primitive-int-05_dump_e2e | Rounds: 50 | Iterations: 1': 4 tests --------------------------------------------------------------------------------
Name (time in ms)                                                                 Min              Max             Mean            StdDev            Median            IQR            Outliers  Avg Bytes              Total Bytes
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_05_dump_e2e[cachew-sqlite-primitive-int-100k] (NOW)                         60.7 (1.0)       64.9 (1.0)       62.8 (1.0)         0.9 (1.0)        62.8 (1.0)      1.3 (1.0)          14;0     4.8889         488890
test_05_dump_e2e[cachew-sqlite-primitive-int-100k] (0006_baselin)                60.8 (1.00)     136.4 (2.10)      70.1 (1.12)       15.4 (16.68)      63.9 (1.02)     4.6 (3.43)         4;11     4.8889         488890
test_05_real_dump_e2e[cachew-real-sqlite-primitive-int-100k] (NOW)               75.2 (1.24)      83.3 (1.28)      78.6 (1.25)        1.7 (1.89)       79.1 (1.26)     2.1 (1.57)         12;1     4.8889         488890
test_05_real_dump_e2e[cachew-real-sqlite-primitive-int-100k] (0006_baselin)     153.1 (2.52)     163.7 (2.52)     157.5 (2.51)        1.9 (2.11)      157.6 (2.51)     2.6 (1.93)         14;1     4.8889         488890
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

-------------------------------------------------------------------------------- benchmark 'union-dataclass-05_dump_e2e | Rounds: 50 | Iterations: 1': 4 tests ---------------------------------------------------------------------------------
Name (time in ms)                                                                   Min              Max             Mean            StdDev            Median            IQR            Outliers  Avg Bytes                Total Bytes
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_05_dump_e2e[cachew-sqlite-union-dataclass-100k] (0006_baselin)               146.8 (1.0)      165.5 (1.06)     153.4 (1.0)         4.1 (1.96)      153.5 (1.00)     5.2 (2.04)         13;2    51.7778          5177780
test_05_dump_e2e[cachew-sqlite-union-dataclass-100k] (NOW)                        148.4 (1.01)     156.7 (1.0)      153.4 (1.00)        2.1 (1.0)       153.5 (1.0)      2.9 (1.14)         15;0    51.7778          5177780
test_05_real_dump_e2e[cachew-real-sqlite-union-dataclass-100k] (NOW)              167.2 (1.14)     174.8 (1.12)     170.1 (1.11)        2.2 (1.04)      169.5 (1.10)     3.0 (1.17)         13;0    51.7778          5177780
test_05_real_dump_e2e[cachew-real-sqlite-union-dataclass-100k] (0006_baselin)     247.3 (1.68)     256.3 (1.64)     252.3 (1.64)        2.2 (1.04)      252.5 (1.64)     2.5 (1.0)          12;1    51.7778          5177780
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```